### PR TITLE
Use standard reboot module and add a timeout

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,4 +1,5 @@
 - name: Restart system
-  ansible.builtin.command:
-    cmd: reboot
+  ansible.builtin.reboot:
+   msg: "Reboot by ansible because the kernel boot parameters are changed"
+   reboot_timeout: 300
   when: ansible_virtualization_role != "guest"


### PR DESCRIPTION
When using this role in a playbook followed by other tasks then the reboot breaks the next task because the device is unavailable during reboot.

By using the standard ansible reboot module and allowing a timeout for the reboot the playbook can continue with other tasks after a reboot.